### PR TITLE
Torch models to pytorch models, bug fix, CPU support, etc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PhotoWCTModels"]
+	path = PhotoWCTModels
+	url = https://github.com/suquark/PhotoWCTModels.git

--- a/USAGE.md
+++ b/USAGE.md
@@ -32,12 +32,12 @@ These models are extracted from Torch7 models and currently used in the project.
 
 - Pull them from the `PhotoWCTModels` submodule: `git submodule update --init --recursive`
 
-**Origin Torch7 models**
+**Original Torch7 models**
 
 - Download pretrained networks via the following [link](https://drive.google.com/open?id=1ENgQm9TgabE1R99zhNf5q6meBvX6WFuq).
 - Unzip and store the model files under `models`.
 
-`converter.py` shows how to convert Torth7 models to PyTorch models.
+`converter.py` shows how to convert Torch7 models to PyTorch models.
 
 ### Example 1: Transfer the style of a style photo to a content photo.
 - Create image and output folders and make sure nothing is inside the folders. `mkdir images && mkdir results`

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,8 +26,18 @@ We only tested our code in the following environment.
 
 ### Download pretrained networks
 
+**PyTorch models**
+
+These models are extracted from Torch7 models and currently used in the project.
+
+- Pull them from the `PhotoWCTModels` submodule: `git submodule update --init --recursive`
+
+**Origin Torch7 models**
+
 - Download pretrained networks via the following [link](https://drive.google.com/open?id=1ENgQm9TgabE1R99zhNf5q6meBvX6WFuq).
 - Unzip and store the model files under `models`.
+
+`converter.py` shows how to convert Torth7 models to PyTorch models.
 
 ### Example 1: Transfer the style of a style photo to a content photo.
 - Create image and output folders and make sure nothing is inside the folders. `mkdir images && mkdir results`

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,130 @@
+import os
+
+import torch
+import torch.nn as nn
+from torch.utils.serialization import load_lua
+
+from models import VGGEncoder, VGGDecoder
+from photo_wct import PhotoWCT
+
+
+def weight_assign(lua, pth, maps):
+    for k, v in maps.items():
+        getattr(pth, k).weight = nn.Parameter(lua.get(v).weight.float())
+        getattr(pth, k).bias = nn.Parameter(lua.get(v).bias.float())
+
+
+def photo_wct_loader(p_wct):
+    p_wct.e1.load_state_dict(torch.load('pth_models/vgg_normalised_conv1.pth'))
+    p_wct.d1.load_state_dict(torch.load('pth_models/feature_invertor_conv1.pth'))
+    p_wct.e2.load_state_dict(torch.load('pth_models/vgg_normalised_conv2.pth'))
+    p_wct.d2.load_state_dict(torch.load('pth_models/feature_invertor_conv2.pth'))
+    p_wct.e3.load_state_dict(torch.load('pth_models/vgg_normalised_conv3.pth'))
+    p_wct.d3.load_state_dict(torch.load('pth_models/feature_invertor_conv3.pth'))
+    p_wct.e4.load_state_dict(torch.load('pth_models/vgg_normalised_conv4.pth'))
+    p_wct.d4.load_state_dict(torch.load('pth_models/feature_invertor_conv4.pth'))
+
+
+if __name__ == '__main__':
+    if not os.path.exists('pth_models'):
+        os.mkdir('pth_models')
+    
+    ## VGGEncoder1
+    vgg1 = load_lua('models/vgg_normalised_conv1_1_mask.t7')
+    e1 = VGGEncoder(1)
+    weight_assign(vgg1, e1, {
+        'conv0': 0,
+        'conv1_1': 2,
+    })
+    torch.save(e1.state_dict(), 'pth_models/vgg_normalised_conv1.pth')
+    
+    ## VGGDecoder1
+    inv1 = load_lua('models/feature_invertor_conv1_1_mask.t7')
+    d1 = VGGDecoder(1)
+    weight_assign(inv1, d1, {
+        'conv1_1': 1,
+    })
+    torch.save(d1.state_dict(), 'pth_models/feature_invertor_conv1.pth')
+    
+    ## VGGEncoder2
+    vgg2 = load_lua('models/vgg_normalised_conv2_1_mask.t7')
+    e2 = VGGEncoder(2)
+    weight_assign(vgg2, e2, {
+        'conv0': 0,
+        'conv1_1': 2,
+        'conv1_2': 5,
+        'conv2_1': 9,
+    })
+    torch.save(e2.state_dict(), 'pth_models/vgg_normalised_conv2.pth')
+    
+    ## VGGDecoder2
+    inv2 = load_lua('models/feature_invertor_conv2_1_mask.t7')
+    d2 = VGGDecoder(2)
+    weight_assign(inv2, d2, {
+        'conv2_1': 1,
+        'conv1_2': 5,
+        'conv1_1': 8,
+    })
+    torch.save(d2.state_dict(), 'pth_models/feature_invertor_conv2.pth')
+    
+    ## VGGEncoder3
+    vgg3 = load_lua('models/vgg_normalised_conv3_1_mask.t7')
+    e3 = VGGEncoder(3)
+    weight_assign(vgg3, e3, {
+        'conv0': 0,
+        'conv1_1': 2,
+        'conv1_2': 5,
+        'conv2_1': 9,
+        'conv2_2': 12,
+        'conv3_1': 16,
+    })
+    torch.save(e3.state_dict(), 'pth_models/vgg_normalised_conv3.pth')
+    
+    ## VGGDecoder3
+    inv3 = load_lua('models/feature_invertor_conv3_1_mask.t7')
+    d3 = VGGDecoder(3)
+    weight_assign(inv3, d3, {
+        'conv3_1': 1,
+        'conv2_2': 5,
+        'conv2_1': 8,
+        'conv1_2': 12,
+        'conv1_1': 15,
+    })
+    torch.save(d3.state_dict(), 'pth_models/feature_invertor_conv3.pth')
+    
+    ## VGGEncoder4
+    vgg4 = load_lua('models/vgg_normalised_conv4_1_mask.t7')
+    e4 = VGGEncoder(4)
+    weight_assign(vgg4, e4, {
+        'conv0': 0,
+        'conv1_1': 2,
+        'conv1_2': 5,
+        'conv2_1': 9,
+        'conv2_2': 12,
+        'conv3_1': 16,
+        'conv3_2': 19,
+        'conv3_3': 22,
+        'conv3_4': 25,
+        'conv4_1': 29,
+    })
+    torch.save(e4.state_dict(), 'pth_models/vgg_normalised_conv4.pth')
+    
+    ## VGGDecoder4
+    inv4 = load_lua('models/feature_invertor_conv4_1_mask.t7')
+    d4 = VGGDecoder(4)
+    weight_assign(inv4, d4, {
+        'conv4_1': 1,
+        'conv3_4': 5,
+        'conv3_3': 8,
+        'conv3_2': 11,
+        'conv3_1': 14,
+        'conv2_2': 18,
+        'conv2_1': 21,
+        'conv1_2': 25,
+        'conv1_1': 28,
+    })
+    torch.save(d4.state_dict(), 'pth_models/feature_invertor_conv4.pth')
+    
+    p_wct = PhotoWCT()
+    photo_wct_loader(p_wct)
+    torch.save(p_wct.state_dict(), 'PhotoWCTModels/photo_wct.pth')

--- a/demo.py
+++ b/demo.py
@@ -5,20 +5,13 @@ Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses
 
 import argparse
 
+import torch
+
 import process_stylization
 from photo_wct import PhotoWCT
 
 parser = argparse.ArgumentParser(description='Photorealistic Image Stylization')
-parser.add_argument('--vgg1', default='./models/vgg_normalised_conv1_1_mask.t7', help='Path to the VGG conv1_1')
-parser.add_argument('--vgg2', default='./models/vgg_normalised_conv2_1_mask.t7', help='Path to the VGG conv2_1')
-parser.add_argument('--vgg3', default='./models/vgg_normalised_conv3_1_mask.t7', help='Path to the VGG conv3_1')
-parser.add_argument('--vgg4', default='./models/vgg_normalised_conv4_1_mask.t7', help='Path to the VGG conv4_1')
-parser.add_argument('--vgg5', default='./models/vgg_normalised_conv5_1_mask.t7', help='Path to the VGG conv5_1')
-parser.add_argument('--decoder5', default='./models/feature_invertor_conv5_1_mask.t7', help='Path to the decoder5')
-parser.add_argument('--decoder4', default='./models/feature_invertor_conv4_1_mask.t7', help='Path to the decoder4')
-parser.add_argument('--decoder3', default='./models/feature_invertor_conv3_1_mask.t7', help='Path to the decoder3')
-parser.add_argument('--decoder2', default='./models/feature_invertor_conv2_1_mask.t7', help='Path to the decoder2')
-parser.add_argument('--decoder1', default='./models/feature_invertor_conv1_1_mask.t7', help='Path to the decoder1')
+parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth', help='Path to the PhotoWCT model')
 parser.add_argument('--content_image_path', default='./images/content1.png')
 parser.add_argument('--content_seg_path', default=[])
 parser.add_argument('--style_image_path', default='./images/style1.png')
@@ -27,7 +20,8 @@ parser.add_argument('--output_image_path', default='./results/example1.png')
 args = parser.parse_args()
 
 # Load model
-p_wct = PhotoWCT(args)
+p_wct = PhotoWCT()
+p_wct.load_state_dict(torch.load(args.model))
 p_wct.cuda(0)
 
 process_stylization.stylization(

--- a/demo.py
+++ b/demo.py
@@ -3,6 +3,7 @@ Copyright (C) 2018 NVIDIA Corporation.  All rights reserved.
 Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 """
 
+from __future__ import print_function
 import argparse
 
 import torch
@@ -11,7 +12,8 @@ import process_stylization
 from photo_wct import PhotoWCT
 
 parser = argparse.ArgumentParser(description='Photorealistic Image Stylization')
-parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth', help='Path to the PhotoWCT model')
+parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth',
+                    help='Path to the PhotoWCT model. These are provided by the PhotoWCT submodule, please use `git submodule update --init --recursive` to pull.')
 parser.add_argument('--content_image_path', default='./images/content1.png')
 parser.add_argument('--content_seg_path', default=[])
 parser.add_argument('--style_image_path', default='./images/style1.png')
@@ -21,7 +23,12 @@ args = parser.parse_args()
 
 # Load model
 p_wct = PhotoWCT()
-p_wct.load_state_dict(torch.load(args.model))
+try:
+    p_wct.load_state_dict(torch.load(args.model))
+except:
+    print("Fail to load PhotoWCT models. PhotoWCT submodule not updated?")
+    exit()
+    
 p_wct.cuda(0)
 
 process_stylization.stylization(

--- a/models.py
+++ b/models.py
@@ -4,525 +4,294 @@ Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses
 """
 import torch.nn as nn
 
-class VGGEncoder1(nn.Module):
-  def __init__(self, vgg1):
-    super(VGGEncoder1, self).__init__()
-    # 224 x 224
-    self.conv1 = nn.Conv2d(3, 3, 1, 1, 0)
-    self.conv1.weight = nn.Parameter(vgg1.get(0).weight.float())
-    self.conv1.bias = nn.Parameter(vgg1.get(0).bias.float())
-    # 224 x 224
-    self.reflect_pad1 = nn.ReflectionPad2d((1, 1, 1, 1))
-    # 226 x 226
-    self.conv2 = nn.Conv2d(3, 64, 3, 1, 0)
-    self.conv2.weight = nn.Parameter(vgg1.get(2).weight.float())
-    self.conv2.bias = nn.Parameter(vgg1.get(2).bias.float())
-    self.relu = nn.ReLU(inplace=True)
-    # 224 x 224
 
-  def forward(self, x):
-    out = self.conv1(x)
-    out = self.reflect_pad1(out)
-    out = self.conv2(out)
-    out = self.relu(out)
-    return out
-
-
-class VGGDecoder1(nn.Module):
-  def __init__(self, d1):
-    super(VGGDecoder1, self).__init__()
-    self.reflect_pad2 = nn.ReflectionPad2d((1, 1, 1, 1))
-    # 226 x 226
-    self.conv3 = nn.Conv2d(64, 3, 3, 1, 0)
-    self.conv3.weight = nn.Parameter(d1.get(1).weight.float())
-    self.conv3.bias = nn.Parameter(d1.get(1).bias.float())
-    # 224 x 224
-
-  def forward(self, x):
-    out = self.reflect_pad2(x)
-    out = self.conv3(out)
-    return out
-
-
-class VGGEncoder2(nn.Module):
-  def __init__(self, vgg):
-    super(VGGEncoder2, self).__init__()
-    # 224 x 224
-    self.conv1 = nn.Conv2d(3, 3, 1, 1, 0)
-    self.conv1.weight = nn.Parameter(vgg.get(0).weight.float())
-    self.conv1.bias = nn.Parameter(vgg.get(0).bias.float())
-    self.reflect_pad2 = nn.ReflectionPad2d((1, 1, 1, 1))
-    # 226 x 226
-
-    self.conv2 = nn.Conv2d(3, 64, 3, 1, 0)
-    self.conv2.weight = nn.Parameter(vgg.get(2).weight.float())
-    self.conv2.bias = nn.Parameter(vgg.get(2).bias.float())
-    self.relu2 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.reflect_pad3 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv3 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv3.weight = nn.Parameter(vgg.get(5).weight.float())
-    self.conv3.bias = nn.Parameter(vgg.get(5).bias.float())
-    self.relu3 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.maxPool = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 112 x 112
-
-    self.reflect_pad4 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv4 = nn.Conv2d(64, 128, 3, 1, 0)
-    self.conv4.weight = nn.Parameter(vgg.get(9).weight.float())
-    self.conv4.bias = nn.Parameter(vgg.get(9).bias.float())
-    self.relu4 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-  def forward(self, x):
-    out = self.conv1(x)
-    out = self.reflect_pad2(out)
-    out = self.conv2(out)
-    out = self.relu2(out)
-    out = self.reflect_pad3(out)
-    out = self.conv3(out)
-    pool = self.relu3(out)
-    out, pool_idx = self.maxPool(pool)
-    out = self.reflect_pad4(out)
-    out = self.conv4(out)
-    out = self.relu4(out)
-    return out, pool_idx, pool.size()
-
-
-class VGGDecoder2(nn.Module):
-  def __init__(self, d):
-    super(VGGDecoder2, self).__init__()
-    # decoder
-    self.reflect_pad5 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv5 = nn.Conv2d(128, 64, 3, 1, 0)
-    self.conv5.weight = nn.Parameter(d.get(1).weight.float())
-    self.conv5.bias = nn.Parameter(d.get(1).bias.float())
-    self.relu5 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.unpool = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # self.unpool = nn.Upsample(2,2)
-    # 224 x 224
-
-    self.reflect_pad6 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv6 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv6.weight = nn.Parameter(d.get(5).weight.float())
-    self.conv6.bias = nn.Parameter(d.get(5).bias.float())
-    self.relu6 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.reflect_pad7 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv7 = nn.Conv2d(64, 3, 3, 1, 0)
-    self.conv7.weight = nn.Parameter(d.get(8).weight.float())
-    self.conv7.bias = nn.Parameter(d.get(8).bias.float())
-
-  def forward(self, x, pool_idx, pool):
-    out = self.reflect_pad5(x)
-    out = self.conv5(out)
-    out = self.relu5(out)
-    out = self.unpool(out, pool_idx, output_size=pool)
-    out = self.reflect_pad6(out)
-    out = self.conv6(out)
-    out = self.relu6(out)
-    out = self.reflect_pad7(out)
-    out = self.conv7(out)
-    return out
-
-
-class VGGEncoder3(nn.Module):
-  def __init__(self, vgg):
-    super(VGGEncoder3, self).__init__()
-    # 224 x 224
-    self.conv1 = nn.Conv2d(3, 3, 1, 1, 0)
-    self.conv1.weight = nn.Parameter(vgg.get(0).weight.float())
-    self.conv1.bias = nn.Parameter(vgg.get(0).bias.float())
-    self.reflect_pad1 = nn.ReflectionPad2d((1, 1, 1, 1))
-    # 226 x 226
-
-    self.conv2 = nn.Conv2d(3, 64, 3, 1, 0)
-    self.conv2.weight = nn.Parameter(vgg.get(2).weight.float())
-    self.conv2.bias = nn.Parameter(vgg.get(2).bias.float())
-    self.relu2 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.reflect_pad3 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv3 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv3.weight = nn.Parameter(vgg.get(5).weight.float())
-    self.conv3.bias = nn.Parameter(vgg.get(5).bias.float())
-    self.relu3 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.maxPool = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 112 x 112
-
-    self.reflect_pad4 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv4 = nn.Conv2d(64, 128, 3, 1, 0)
-    self.conv4.weight = nn.Parameter(vgg.get(9).weight.float())
-    self.conv4.bias = nn.Parameter(vgg.get(9).bias.float())
-    self.relu4 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.reflect_pad5 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv5 = nn.Conv2d(128, 128, 3, 1, 0)
-    self.conv5.weight = nn.Parameter(vgg.get(12).weight.float())
-    self.conv5.bias = nn.Parameter(vgg.get(12).bias.float())
-    self.relu5 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.maxPool2 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 56 x 56
-
-    self.reflect_pad6 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv6 = nn.Conv2d(128, 256, 3, 1, 0)
-    self.conv6.weight = nn.Parameter(vgg.get(16).weight.float())
-    self.conv6.bias = nn.Parameter(vgg.get(16).bias.float())
-    self.relu6 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-  def forward(self, x):
-    out = self.conv1(x)
-    out = self.reflect_pad1(out)
-    out = self.conv2(out)
-    out = self.relu2(out)
-    out = self.reflect_pad3(out)
-    out = self.conv3(out)
-    pool1 = self.relu3(out)
-    out, pool_idx = self.maxPool(pool1)
-    out = self.reflect_pad4(out)
-    out = self.conv4(out)
-    out = self.relu4(out)
-    out = self.reflect_pad5(out)
-    out = self.conv5(out)
-    pool2 = self.relu5(out)
-    out, pool_idx2 = self.maxPool2(pool2)
-    out = self.reflect_pad6(out)
-    out = self.conv6(out)
-    out = self.relu6(out)
-    return out, pool_idx, pool1.size(), pool_idx2, pool2.size()
-
-
-class VGGDecoder3(nn.Module):
-  def __init__(self, d):
-    super(VGGDecoder3, self).__init__()
-    # decoder
-    self.reflect_pad7 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv7 = nn.Conv2d(256, 128, 3, 1, 0)
-    self.conv7.weight = nn.Parameter(d.get(1).weight.float())
-    self.conv7.bias = nn.Parameter(d.get(1).bias.float())
-    self.relu7 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.unpool = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # self.unpool = nn.Upsample(2,2)
-    # 112 x 112
-
-    self.reflect_pad8 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv8 = nn.Conv2d(128, 128, 3, 1, 0)
-    self.conv8.weight = nn.Parameter(d.get(5).weight.float())
-    self.conv8.bias = nn.Parameter(d.get(5).bias.float())
-    self.relu8 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.reflect_pad9 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv9 = nn.Conv2d(128, 64, 3, 1, 0)
-    self.conv9.weight = nn.Parameter(d.get(8).weight.float())
-    self.conv9.bias = nn.Parameter(d.get(8).bias.float())
-    self.relu9 = nn.ReLU(inplace=True)
-
-    self.unpool2 = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # 224 x 224
-
-    self.reflect_pad10 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv10 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv10.weight = nn.Parameter(d.get(12).weight.float())
-    self.conv10.bias = nn.Parameter(d.get(12).bias.float())
-    self.relu10 = nn.ReLU(inplace=True)
-
-    self.reflect_pad11 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv11 = nn.Conv2d(64, 3, 3, 1, 0)
-    self.conv11.weight = nn.Parameter(d.get(15).weight.float())
-    self.conv11.bias = nn.Parameter(d.get(15).bias.float())
-
-  def forward(self, x, pool_idx, pool1, pool_idx2, pool2):
-    out = self.reflect_pad7(x)
-    out = self.conv7(out)
-    out = self.relu7(out)
-    out = self.unpool(out, pool_idx2, output_size=pool2)
-    out = self.reflect_pad8(out)
-    out = self.conv8(out)
-    out = self.relu8(out)
-    out = self.reflect_pad9(out)
-    out = self.conv9(out)
-    out = self.relu9(out)
-    out = self.unpool2(out, pool_idx, output_size=pool1)
-    out = self.reflect_pad10(out)
-    out = self.conv10(out)
-    out = self.relu10(out)
-    out = self.reflect_pad11(out)
-    out = self.conv11(out)
-    return out
-
-
-class VGGEncoder4(nn.Module):
-  def __init__(self, vgg):
-    super(VGGEncoder4, self).__init__()
-    # vgg
-    # 224 x 224
-    self.conv1 = nn.Conv2d(3, 3, 1, 1, 0)
-    self.conv1.weight = nn.Parameter(vgg.get(0).weight.float())
-    self.conv1.bias = nn.Parameter(vgg.get(0).bias.float())
-    self.reflect_pad1 = nn.ReflectionPad2d((1, 1, 1, 1))
-    # 226 x 226
-
-    self.conv2 = nn.Conv2d(3, 64, 3, 1, 0)
-    self.conv2.weight = nn.Parameter(vgg.get(2).weight.float())
-    self.conv2.bias = nn.Parameter(vgg.get(2).bias.float())
-    self.relu2 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.reflect_pad3 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv3 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv3.weight = nn.Parameter(vgg.get(5).weight.float())
-    self.conv3.bias = nn.Parameter(vgg.get(5).bias.float())
-    self.relu3 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.maxPool = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 112 x 112
-
-    self.reflect_pad4 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv4 = nn.Conv2d(64, 128, 3, 1, 0)
-    self.conv4.weight = nn.Parameter(vgg.get(9).weight.float())
-    self.conv4.bias = nn.Parameter(vgg.get(9).bias.float())
-    self.relu4 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.reflect_pad5 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv5 = nn.Conv2d(128, 128, 3, 1, 0)
-    self.conv5.weight = nn.Parameter(vgg.get(12).weight.float())
-    self.conv5.bias = nn.Parameter(vgg.get(12).bias.float())
-    self.relu5 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.maxPool2 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 56 x 56
-
-    self.reflect_pad6 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv6 = nn.Conv2d(128, 256, 3, 1, 0)
-    self.conv6.weight = nn.Parameter(vgg.get(16).weight.float())
-    self.conv6.bias = nn.Parameter(vgg.get(16).bias.float())
-    self.relu6 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad7 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv7 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv7.weight = nn.Parameter(vgg.get(19).weight.float())
-    self.conv7.bias = nn.Parameter(vgg.get(19).bias.float())
-    self.relu7 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad8 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv8 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv8.weight = nn.Parameter(vgg.get(22).weight.float())
-    self.conv8.bias = nn.Parameter(vgg.get(22).bias.float())
-    self.relu8 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad9 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv9 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv9.weight = nn.Parameter(vgg.get(25).weight.float())
-    self.conv9.bias = nn.Parameter(vgg.get(25).bias.float())
-    self.relu9 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.maxPool3 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
-    # 28 x 28
-
-    self.reflect_pad10 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv10 = nn.Conv2d(256, 512, 3, 1, 0)
-    self.conv10.weight = nn.Parameter(vgg.get(29).weight.float())
-    self.conv10.bias = nn.Parameter(vgg.get(29).bias.float())
-    self.relu10 = nn.ReLU(inplace=True)
-    # 28 x 28
-
-  def forward(self, x):
-    out = self.conv1(x)
-    out = self.reflect_pad1(out)
-    out = self.conv2(out)
-    out = self.relu2(out)
-    out = self.reflect_pad3(out)
-    out = self.conv3(out)
-    pool1 = self.relu3(out)
-    out, pool_idx = self.maxPool(pool1)
-    out = self.reflect_pad4(out)
-    out = self.conv4(out)
-    out = self.relu4(out)
-    out = self.reflect_pad5(out)
-    out = self.conv5(out)
-    pool2 = self.relu5(out)
-    out, pool_idx2 = self.maxPool2(pool2)
-    out = self.reflect_pad6(out)
-    out = self.conv6(out)
-    out = self.relu6(out)
-    out = self.reflect_pad7(out)
-    out = self.conv7(out)
-    out = self.relu7(out)
-    out = self.reflect_pad8(out)
-    out = self.conv8(out)
-    out = self.relu8(out)
-    out = self.reflect_pad9(out)
-    out = self.conv9(out)
-    pool3 = self.relu9(out)
-    out, pool_idx3 = self.maxPool3(pool3)
-    out = self.reflect_pad10(out)
-    out = self.conv10(out)
-    out = self.relu10(out)
-    return out, pool_idx, pool1.size(), pool_idx2, pool2.size(), pool_idx3, pool3.size()
-
-
-  def forward_multiple(self, x):
-    out0 = self.conv1(x)
-    out0 = self.reflect_pad1(out0)
-    out0 = self.conv2(out0)
-    out0 = self.relu2(out0)
-    out1 = self.reflect_pad3(out0)
-    out1 = self.conv3(out1)
-    pool1 = self.relu3(out1)
-    out1, pool_idx = self.maxPool(pool1)
-    out1 = self.reflect_pad4(out1)
-    out1 = self.conv4(out1)
-    out1 = self.relu4(out1)
-    out2 = self.reflect_pad5(out1)
-    out2 = self.conv5(out2)
-    pool2 = self.relu5(out2)
-    out2, pool_idx2 = self.maxPool2(pool2)
-    out2 = self.reflect_pad6(out2)
-    out2 = self.conv6(out2)
-    out2 = self.relu6(out2)
-    out = self.reflect_pad7(out2)
-    out = self.conv7(out)
-    out = self.relu7(out)
-    out = self.reflect_pad8(out)
-    out = self.conv8(out)
-    out = self.relu8(out)
-    out = self.reflect_pad9(out)
-    out = self.conv9(out)
-    pool3 = self.relu9(out)
-    out, pool_idx3 = self.maxPool3(pool3)
-    out = self.reflect_pad10(out)
-    out = self.conv10(out)
-    out = self.relu10(out)
-    return out, out2, out1, out0
-
-class VGGDecoder4(nn.Module):
-  def __init__(self, d):
-    super(VGGDecoder4, self).__init__()
-    # decoder
-    self.reflect_pad11 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv11 = nn.Conv2d(512, 256, 3, 1, 0)
-    self.conv11.weight = nn.Parameter(d.get(1).weight.float())
-    self.conv11.bias = nn.Parameter(d.get(1).bias.float())
-    self.relu11 = nn.ReLU(inplace=True)
-    # 28 x 28
-
-    self.unpool = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # 56 x 56
-
-    self.reflect_pad12 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv12 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv12.weight = nn.Parameter(d.get(5).weight.float())
-    self.conv12.bias = nn.Parameter(d.get(5).bias.float())
-    self.relu12 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad13 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv13 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv13.weight = nn.Parameter(d.get(8).weight.float())
-    self.conv13.bias = nn.Parameter(d.get(8).bias.float())
-    self.relu13 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad14 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv14 = nn.Conv2d(256, 256, 3, 1, 0)
-    self.conv14.weight = nn.Parameter(d.get(11).weight.float())
-    self.conv14.bias = nn.Parameter(d.get(11).bias.float())
-    self.relu14 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.reflect_pad15 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv15 = nn.Conv2d(256, 128, 3, 1, 0)
-    self.conv15.weight = nn.Parameter(d.get(14).weight.float())
-    self.conv15.bias = nn.Parameter(d.get(14).bias.float())
-    self.relu15 = nn.ReLU(inplace=True)
-    # 56 x 56
-
-    self.unpool2 = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # 112 x 112
-
-    self.reflect_pad16 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv16 = nn.Conv2d(128, 128, 3, 1, 0)
-    self.conv16.weight = nn.Parameter(d.get(18).weight.float())
-    self.conv16.bias = nn.Parameter(d.get(18).bias.float())
-    self.relu16 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.reflect_pad17 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv17 = nn.Conv2d(128, 64, 3, 1, 0)
-    self.conv17.weight = nn.Parameter(d.get(21).weight.float())
-    self.conv17.bias = nn.Parameter(d.get(21).bias.float())
-    self.relu17 = nn.ReLU(inplace=True)
-    # 112 x 112
-
-    self.unpool3 = nn.MaxUnpool2d(kernel_size=2, stride=2)
-    # 224 x 224
-
-    self.reflect_pad18 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv18 = nn.Conv2d(64, 64, 3, 1, 0)
-    self.conv18.weight = nn.Parameter(d.get(25).weight.float())
-    self.conv18.bias = nn.Parameter(d.get(25).bias.float())
-    self.relu18 = nn.ReLU(inplace=True)
-    # 224 x 224
-
-    self.reflect_pad19 = nn.ReflectionPad2d((1, 1, 1, 1))
-    self.conv19 = nn.Conv2d(64, 3, 3, 1, 0)
-    self.conv19.weight = nn.Parameter(d.get(28).weight.float())
-    self.conv19.bias = nn.Parameter(d.get(28).bias.float())
-
-  def forward(self, x, pool_idx, pool1, pool_idx2, pool2, pool_idx3, pool3):
-    # decoder
-    out = self.reflect_pad11(x)
-    out = self.conv11(out)
-    out = self.relu11(out)
-    out = self.unpool(out, pool_idx3, output_size=pool3)
-    out = self.reflect_pad12(out)
-    out = self.conv12(out)
-
-    out = self.relu12(out)
-    out = self.reflect_pad13(out)
-    out = self.conv13(out)
-    out = self.relu13(out)
-    out = self.reflect_pad14(out)
-    out = self.conv14(out)
-    out = self.relu14(out)
-    out = self.reflect_pad15(out)
-    out = self.conv15(out)
-    out = self.relu15(out)
-    out = self.unpool2(out, pool_idx2, output_size=pool2)
-    out = self.reflect_pad16(out)
-    out = self.conv16(out)
-    out = self.relu16(out)
-    out = self.reflect_pad17(out)
-    out = self.conv17(out)
-    out = self.relu17(out)
-    out = self.unpool3(out, pool_idx, output_size=pool1)
-    out = self.reflect_pad18(out)
-    out = self.conv18(out)
-    out = self.relu18(out)
-    out = self.reflect_pad19(out)
-    out = self.conv19(out)
-    return out
-
-
+class VGGEncoder(nn.Module):
+    def __init__(self, level):
+        super(VGGEncoder, self).__init__()
+        self.level = level
+        
+        # 224 x 224
+        self.conv0 = nn.Conv2d(3, 3, 1, 1, 0)
+        
+        self.pad1_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+        # 226 x 226
+        self.conv1_1 = nn.Conv2d(3, 64, 3, 1, 0)
+        self.relu1_1 = nn.ReLU(inplace=True)
+        # 224 x 224
+        
+        if level < 2: return
+        
+        self.pad1_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv1_2 = nn.Conv2d(64, 64, 3, 1, 0)
+        self.relu1_2 = nn.ReLU(inplace=True)
+        # 224 x 224
+        self.maxpool1 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
+        # 112 x 112
+        
+        self.pad2_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv2_1 = nn.Conv2d(64, 128, 3, 1, 0)
+        self.relu2_1 = nn.ReLU(inplace=True)
+        # 112 x 112
+        
+        if level < 3: return
+        
+        self.pad2_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv2_2 = nn.Conv2d(128, 128, 3, 1, 0)
+        self.relu2_2 = nn.ReLU(inplace=True)
+        # 112 x 112
+        
+        self.maxpool2 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
+        # 56 x 56
+        
+        self.pad3_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv3_1 = nn.Conv2d(128, 256, 3, 1, 0)
+        self.relu3_1 = nn.ReLU(inplace=True)
+        # 56 x 56
+        
+        if level < 4: return
+        
+        self.pad3_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv3_2 = nn.Conv2d(256, 256, 3, 1, 0)
+        self.relu3_2 = nn.ReLU(inplace=True)
+        # 56 x 56
+        
+        self.pad3_3 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv3_3 = nn.Conv2d(256, 256, 3, 1, 0)
+        self.relu3_3 = nn.ReLU(inplace=True)
+        # 56 x 56
+        
+        self.pad3_4 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv3_4 = nn.Conv2d(256, 256, 3, 1, 0)
+        self.relu3_4 = nn.ReLU(inplace=True)
+        # 56 x 56
+        
+        self.maxpool3 = nn.MaxPool2d(kernel_size=2, stride=2, return_indices=True)
+        # 28 x 28
+        
+        self.pad4_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+        self.conv4_1 = nn.Conv2d(256, 512, 3, 1, 0)
+        self.relu4_1 = nn.ReLU(inplace=True)
+        # 28 x 28
+    
+    def forward(self, x):
+        out = self.conv0(x)
+        
+        out = self.pad1_1(out)
+        out = self.conv1_1(out)
+        out = self.relu1_1(out)
+        
+        if self.level < 2:
+            return out
+        
+        out = self.pad1_2(out)
+        out = self.conv1_2(out)
+        pool1 = self.relu1_2(out)
+        
+        out, pool1_idx = self.maxpool1(pool1)
+        
+        out = self.pad2_1(out)
+        out = self.conv2_1(out)
+        out = self.relu2_1(out)
+        
+        if self.level < 3:
+            return out, pool1_idx, pool1.size()
+        
+        out = self.pad2_2(out)
+        out = self.conv2_2(out)
+        pool2 = self.relu2_2(out)
+        
+        out, pool2_idx = self.maxpool2(pool2)
+        
+        out = self.pad3_1(out)
+        out = self.conv3_1(out)
+        out = self.relu3_1(out)
+        
+        if self.level < 4:
+            return out, pool1_idx, pool1.size(), pool2_idx, pool2.size()
+        
+        out = self.pad3_2(out)
+        out = self.conv3_2(out)
+        out = self.relu3_2(out)
+        
+        out = self.pad3_3(out)
+        out = self.conv3_3(out)
+        out = self.relu3_3(out)
+        
+        out = self.pad3_4(out)
+        out = self.conv3_4(out)
+        pool3 = self.relu3_4(out)
+        out, pool3_idx = self.maxpool3(pool3)
+        
+        out = self.pad4_1(out)
+        out = self.conv4_1(out)
+        out = self.relu4_1(out)
+        
+        return out, pool1_idx, pool1.size(), pool2_idx, pool2.size(), pool3_idx, pool3.size()
+    
+    def forward_multiple(self, x):
+        out = self.conv0(x)
+        
+        out = self.pad1_1(out)
+        out = self.conv1_1(out)
+        out = self.relu1_1(out)
+        
+        if self.level < 2: return out
+        
+        out1 = out
+        
+        out = self.pad1_2(out)
+        out = self.conv1_2(out)
+        pool1 = self.relu1_2(out)
+        
+        out, pool1_idx = self.maxpool1(pool1)
+        
+        out = self.pad2_1(out)
+        out = self.conv2_1(out)
+        out = self.relu2_1(out)
+        
+        if self.level < 3: return out, out1
+        
+        out2 = out
+        
+        out = self.pad2_2(out)
+        out = self.conv2_2(out)
+        pool2 = self.relu2_2(out)
+        
+        out, pool2_idx = self.maxpool2(pool2)
+        
+        out = self.pad3_1(out)
+        out = self.conv3_1(out)
+        out = self.relu3_1(out)
+        
+        if self.level < 3: return out, out2, out1
+        
+        out3 = out
+        
+        out = self.pad3_2(out)
+        out = self.conv3_2(out)
+        out = self.relu3_2(out)
+        
+        out = self.pad3_3(out)
+        out = self.conv3_3(out)
+        out = self.relu3_3(out)
+        
+        out = self.pad3_4(out)
+        out = self.conv3_4(out)
+        pool3 = self.relu3_4(out)
+        out, pool3_idx = self.maxpool3(pool3)
+        
+        out = self.pad4_1(out)
+        out = self.conv4_1(out)
+        out = self.relu4_1(out)
+        
+        return out, out3, out2, out1
+
+
+class VGGDecoder(nn.Module):
+    def __init__(self, level):
+        super(VGGDecoder, self).__init__()
+        self.level = level
+        
+        if level > 3:
+            self.pad4_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv4_1 = nn.Conv2d(512, 256, 3, 1, 0)
+            self.relu4_1 = nn.ReLU(inplace=True)
+            # 28 x 28
+            
+            self.unpool3 = nn.MaxUnpool2d(kernel_size=2, stride=2)
+            # 56 x 56
+            
+            self.pad3_4 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv3_4 = nn.Conv2d(256, 256, 3, 1, 0)
+            self.relu3_4 = nn.ReLU(inplace=True)
+            # 56 x 56
+            
+            self.pad3_3 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv3_3 = nn.Conv2d(256, 256, 3, 1, 0)
+            self.relu3_3 = nn.ReLU(inplace=True)
+            # 56 x 56
+            
+            self.pad3_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv3_2 = nn.Conv2d(256, 256, 3, 1, 0)
+            self.relu3_2 = nn.ReLU(inplace=True)
+            # 56 x 56
+        
+        if level > 2:
+            self.pad3_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv3_1 = nn.Conv2d(256, 128, 3, 1, 0)
+            self.relu3_1 = nn.ReLU(inplace=True)
+            # 56 x 56
+            
+            self.unpool2 = nn.MaxUnpool2d(kernel_size=2, stride=2)
+            # 112 x 112
+            
+            self.pad2_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv2_2 = nn.Conv2d(128, 128, 3, 1, 0)
+            self.relu2_2 = nn.ReLU(inplace=True)
+            # 112 x 112
+        
+        if level > 1:
+            self.pad2_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv2_1 = nn.Conv2d(128, 64, 3, 1, 0)
+            self.relu2_1 = nn.ReLU(inplace=True)
+            # 112 x 112
+            
+            self.unpool1 = nn.MaxUnpool2d(kernel_size=2, stride=2)
+            # 224 x 224
+            
+            self.pad1_2 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv1_2 = nn.Conv2d(64, 64, 3, 1, 0)
+            self.relu1_2 = nn.ReLU(inplace=True)
+            # 224 x 224
+        
+        if level > 0:
+            self.pad1_1 = nn.ReflectionPad2d((1, 1, 1, 1))
+            self.conv1_1 = nn.Conv2d(64, 3, 3, 1, 0)
+    
+    def forward(self, x, pool1_idx=None, pool1_size=None, pool2_idx=None, pool2_size=None, pool3_idx=None,
+                pool3_size=None):
+        out = x
+        
+        if self.level > 3:
+            out = self.pad4_1(out)
+            out = self.conv4_1(out)
+            out = self.relu4_1(out)
+            out = self.unpool3(out, pool3_idx, output_size=pool3_size)
+            
+            out = self.pad3_4(out)
+            out = self.conv3_4(out)
+            out = self.relu3_4(out)
+            
+            out = self.pad3_3(out)
+            out = self.conv3_3(out)
+            out = self.relu3_3(out)
+            
+            out = self.pad3_2(out)
+            out = self.conv3_2(out)
+            out = self.relu3_2(out)
+        
+        if self.level > 2:
+            out = self.pad3_1(out)
+            out = self.conv3_1(out)
+            out = self.relu3_1(out)
+            out = self.unpool2(out, pool2_idx, output_size=pool2_size)
+            
+            out = self.pad2_2(out)
+            out = self.conv2_2(out)
+            out = self.relu2_2(out)
+        
+        if self.level > 1:
+            out = self.pad2_1(out)
+            out = self.conv2_1(out)
+            out = self.relu2_1(out)
+            out = self.unpool1(out, pool1_idx, output_size=pool1_size)
+            
+            out = self.pad1_2(out)
+            out = self.conv1_2(out)
+            out = self.relu1_2(out)
+        
+        if self.level > 0:
+            out = self.pad1_1(out)
+            out = self.conv1_1(out)
+        
+        return out

--- a/photo_smooth.py
+++ b/photo_smooth.py
@@ -18,8 +18,8 @@ class Propagator(nn.Module):
     self.beta = beta
 
   def process(self, initImg, contentImg):
-    content = scipy.misc.imread(contentImg)
-    B = scipy.misc.imread(initImg).astype(np.float64)/255
+    content = scipy.misc.imread(contentImg, mode='RGB')
+    B = scipy.misc.imread(initImg, mode='RGB').astype(np.float64)/255
     h1,w1,k = B.shape
     h = h1 - 4
     w = w1 - 4

--- a/photo_wct.py
+++ b/photo_wct.py
@@ -2,188 +2,149 @@
 Copyright (C) 2018 NVIDIA Corporation.  All rights reserved.
 Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 """
-from models import *
-import torch
-import torch.nn as nn
-from torch.utils.serialization import load_lua
 
 import numpy as np
-
 from PIL import Image
+import torch
+import torch.nn as nn
+
+from models import VGGEncoder, VGGDecoder
+
 
 class PhotoWCT(nn.Module):
-  def __init__(self, args):
-    super(PhotoWCT, self).__init__()
-    # TODO: convert these torch models to pytorch models.
-    vgg1 = load_lua(args.vgg1)
-    decoder1_torch = load_lua(args.decoder1)
-    vgg2 = load_lua(args.vgg2)
-    decoder2_torch = load_lua(args.decoder2)
-    vgg3 = load_lua(args.vgg3)
-    decoder3_torch = load_lua(args.decoder3)
-    vgg4 = load_lua(args.vgg4)
-    decoder4_torch = load_lua(args.decoder4)
-    self.e1 = VGGEncoder1(vgg1)
-    self.d1 = VGGDecoder1(decoder1_torch)
-    self.e2 = VGGEncoder2(vgg2)
-    self.d2 = VGGDecoder2(decoder2_torch)
-    self.e3 = VGGEncoder3(vgg3)
-    self.d3 = VGGDecoder3(decoder3_torch)
-    self.e4 = VGGEncoder4(vgg4)
-    self.d4 = VGGDecoder4(decoder4_torch)
+    def __init__(self):
+        super(PhotoWCT, self).__init__()
+        
+        self.e1 = VGGEncoder(1)
+        self.d1 = VGGDecoder(1)
+        self.e2 = VGGEncoder(2)
+        self.d2 = VGGDecoder(2)
+        self.e3 = VGGEncoder(3)
+        self.d3 = VGGDecoder(3)
+        self.e4 = VGGEncoder(4)
+        self.d4 = VGGDecoder(4)
+    
+    def transform(self, cont_img, styl_img, cont_seg, styl_seg):
+        self.__compute_label_info(cont_seg, styl_seg)
+        
+        sF4, sF3, sF2, sF1 = self.e4.forward_multiple(styl_img)
+        
+        cF4, cpool_idx, cpool1, cpool_idx2, cpool2, cpool_idx3, cpool3 = self.e4(cont_img)
+        sF4 = sF4.data.squeeze(0)
+        cF4 = cF4.data.squeeze(0)
+        csF4 = self.__feature_wct(cF4, sF4, cont_seg, styl_seg)
+        Im4 = self.d4(csF4, cpool_idx, cpool1, cpool_idx2, cpool2, cpool_idx3, cpool3)
+        
+        cF3, cpool_idx, cpool1, cpool_idx2, cpool2 = self.e3(Im4)
+        sF3 = sF3.data.squeeze(0)
+        cF3 = cF3.data.squeeze(0)
+        csF3 = self.__feature_wct(cF3, sF3, cont_seg, styl_seg)
+        Im3 = self.d3(csF3, cpool_idx, cpool1, cpool_idx2, cpool2)
+        
+        cF2, cpool_idx, cpool = self.e2(Im3)
+        sF2 = sF2.data.squeeze(0)
+        cF2 = cF2.data.squeeze(0)
+        csF2 = self.__feature_wct(cF2, sF2, cont_seg, styl_seg)
+        Im2 = self.d2(csF2, cpool_idx, cpool)
+        
+        cF1 = self.e1(Im2)
+        sF1 = sF1.data.squeeze(0)
+        cF1 = cF1.data.squeeze(0)
+        csF1 = self.__feature_wct(cF1, sF1, cont_seg, styl_seg)
+        Im1 = self.d1(csF1)
+        return Im1
+    
+    def __compute_label_info(self, cont_seg, styl_seg):
+        if cont_seg.size == False or styl_seg.size == False:
+            return
+        max_label = np.max(cont_seg) + 1
+        self.label_set = np.unique(cont_seg)
+        self.label_indicator = np.zeros(max_label)
+        for l in self.label_set:
+            # if l==0:
+            #   continue
+            o_cont_mask = np.where(cont_seg.reshape(cont_seg.shape[0] * cont_seg.shape[1]) == l)
+            o_styl_mask = np.where(styl_seg.reshape(styl_seg.shape[0] * styl_seg.shape[1]) == l)
+            if o_cont_mask[0].size <= 10 or o_styl_mask[0].size <= 10 or \
+                    self.__large_dff(o_cont_mask[0].size, o_styl_mask[0].size):
+                continue
+            self.label_indicator[l] = 1
+    
+    def __feature_wct(self, cont_feat, styl_feat, cont_seg, styl_seg):
+        cont_c, cont_h, cont_w = cont_feat.size(0), cont_feat.size(1), cont_feat.size(2)
+        styl_c, styl_h, styl_w = styl_feat.size(0), styl_feat.size(1), styl_feat.size(2)
+        cont_feat_view = cont_feat.view(cont_c, -1).clone()
+        styl_feat_view = styl_feat.view(styl_c, -1).clone()
+        target_feature = cont_feat.view(cont_c, -1).clone()
+        
+        if cont_seg.size == False or styl_seg.size == False:
+            tmp_target_feature = self.__wct_core(cont_feat_view, styl_feat_view)
+            target_feature = tmp_target_feature.view_as(cont_feat)
+            ccsF = target_feature.float().unsqueeze(0)
+            return ccsF
+        
+        t_cont_seg = np.asarray(Image.fromarray(cont_seg, mode='RGB').resize((cont_w, cont_h), Image.NEAREST))
+        t_styl_seg = np.asarray(Image.fromarray(styl_seg, mode='RGB').resize((styl_w, styl_h), Image.NEAREST))
+        
+        for l in self.label_set:
+            if self.label_indicator[l] == 0:
+                continue
+            cont_mask = np.where(t_cont_seg.reshape(t_cont_seg.shape[0] * t_cont_seg.shape[1]) == l)
+            styl_mask = np.where(t_styl_seg.reshape(t_styl_seg.shape[0] * t_styl_seg.shape[1]) == l)
+            if cont_mask[0].size <= 0 or styl_mask[0].size <= 0:
+                continue
+            cont_indi = torch.LongTensor(cont_mask[0]).cuda(0)
+            styl_indi = torch.LongTensor(styl_mask[0]).cuda(0)
+            cFFG = torch.index_select(cont_feat_view, 1, cont_indi)
+            sFFG = torch.index_select(styl_feat_view, 1, styl_indi)
+            tmp_target_feature = self.__wct_core(cFFG, sFFG)
+            target_feature.index_copy_(1, cont_indi, tmp_target_feature)
+        
+        target_feature = target_feature.view_as(cont_feat)
+        ccsF = target_feature.float().unsqueeze(0)
+        return ccsF
+    
+    def __wct_core(self, cont_feat, styl_feat):
+        cFSize = cont_feat.size()
+        c_mean = torch.mean(cont_feat, 1)  # c x (h x w)
+        c_mean = c_mean.unsqueeze(1).expand_as(cont_feat)
+        cont_feat = cont_feat - c_mean
+        
+        iden = torch.eye(cFSize[0]).cuda()  # .double()
+        contentConv = torch.mm(cont_feat, cont_feat.t()).div(cFSize[1] - 1) + iden
+        # del iden
+        c_u, c_e, c_v = torch.svd(contentConv, some=False)
+        # c_e2, c_v = torch.eig(contentConv, True)
+        # c_e = c_e2[:,0]
+        
+        k_c = cFSize[0]
+        for i in range(cFSize[0] - 1, -1, -1):
+            if c_e[i] >= 0.00001:
+                k_c = i + 1
+                break
+        
+        sFSize = styl_feat.size()
+        s_mean = torch.mean(styl_feat, 1)
+        styl_feat = styl_feat - s_mean.unsqueeze(1).expand_as(styl_feat)
+        styleConv = torch.mm(styl_feat, styl_feat.t()).div(sFSize[1] - 1)
+        s_u, s_e, s_v = torch.svd(styleConv, some=False)
+        
+        k_s = sFSize[0]
+        for i in range(sFSize[0] - 1, -1, -1):
+            if s_e[i] >= 0.00001:
+                k_s = i + 1
+                break
+        
+        c_d = (c_e[0:k_c]).pow(-0.5)
+        step1 = torch.mm(c_v[:, 0:k_c], torch.diag(c_d))
+        step2 = torch.mm(step1, (c_v[:, 0:k_c].t()))
+        whiten_cF = torch.mm(step2, cont_feat)
+        
+        s_d = (s_e[0:k_s]).pow(0.5)
+        targetFeature = torch.mm(torch.mm(torch.mm(s_v[:, 0:k_s], torch.diag(s_d)), (s_v[:, 0:k_s].t())), whiten_cF)
+        targetFeature = targetFeature + s_mean.unsqueeze(1).expand_as(targetFeature)
+        return targetFeature
+    
+    def __large_dff(self, a, b):
+        return a / b >= 100 or b / a >= 100
 
-  def transform(self, cont_img, styl_img, cont_seg, styl_seg):
-    self.__compute_label_info(cont_seg, styl_seg)
-
-    sF4,sF3,sF2,sF1 = self.e4.forward_multiple(styl_img)
-
-    cF4,cpool_idx,cpool1,cpool_idx2,cpool2,cpool_idx3,cpool3 = self.e4(cont_img)
-    sF4 = sF4.data.squeeze(0)
-    cF4 = cF4.data.squeeze(0)
-    csF4 = self.__feature_wct(cF4, sF4, cont_seg, styl_seg)
-    Im4 = self.d4(csF4,cpool_idx,cpool1,cpool_idx2,cpool2,cpool_idx3,cpool3)
-
-    cF3,cpool_idx,cpool1,cpool_idx2,cpool2 = self.e3(Im4)
-    sF3 = sF3.data.squeeze(0)
-    cF3 = cF3.data.squeeze(0)
-    csF3 = self.__feature_wct(cF3, sF3, cont_seg, styl_seg)
-    Im3 = self.d3(csF3,cpool_idx,cpool1,cpool_idx2,cpool2)
-
-    cF2,cpool_idx,cpool = self.e2(Im3)
-    sF2 = sF2.data.squeeze(0)
-    cF2 = cF2.data.squeeze(0)
-    csF2 = self.__feature_wct(cF2, sF2, cont_seg, styl_seg)
-    Im2 = self.d2(csF2,cpool_idx,cpool)
-
-    cF1 = self.e1(Im2)
-    sF1 = sF1.data.squeeze(0)
-    cF1 = cF1.data.squeeze(0)
-    csF1 = self.__feature_wct(cF1, sF1, cont_seg, styl_seg)
-    Im1 = self.d1(csF1)
-    return Im1
-
-  # def transform(self, cont_img, styl_img, cont_seg, styl_seg):
-  #   self.__compute_label_info(cont_seg, styl_seg)
-  #
-  #   cF4,cpool_idx,cpool1,cpool_idx2,cpool2,cpool_idx3,cpool3 = self.e4(cont_img)
-  #   sF4,spool_idx,spool1,spool_idx2,spool2,spool_idx3,spool3 = self.e4(styl_img)
-  #   sF4 = sF4.data.squeeze(0)
-  #   cF4 = cF4.data.squeeze(0)
-  #   csF4 = self.__feature_wct(cF4, sF4, cont_seg, styl_seg)
-  #   Im4 = self.d4(csF4,cpool_idx,cpool1,cpool_idx2,cpool2,cpool_idx3,cpool3)
-  #
-  #   sF3,spool_idx,spool1,spool_idx2,spool2 = self.e3(styl_img)
-  #   cF3,cpool_idx,cpool1,cpool_idx2,cpool2 = self.e3(Im4)
-  #   sF3 = sF3.data.squeeze(0)
-  #   cF3 = cF3.data.squeeze(0)
-  #   csF3 = self.__feature_wct(cF3, sF3, cont_seg, styl_seg)
-  #   Im3 = self.d3(csF3,cpool_idx,cpool1,cpool_idx2,cpool2)
-  #
-  #   sF2,spool_idx,spool= self.e2(styl_img)
-  #   cF2,cpool_idx,cpool = self.e2(Im3)
-  #   sF2 = sF2.data.squeeze(0)
-  #   cF2 = cF2.data.squeeze(0)
-  #   csF2 = self.__feature_wct(cF2, sF2, cont_seg, styl_seg)
-  #   Im2 = self.d2(csF2,cpool_idx,cpool)
-  #
-  #   sF1 = self.e1(styl_img)
-  #   cF1 = self.e1(Im2)
-  #   sF1 = sF1.data.squeeze(0)
-  #   cF1 = cF1.data.squeeze(0)
-  #   csF1 = self.__feature_wct(cF1, sF1, cont_seg, styl_seg)
-  #   Im1 = self.d1(csF1)
-  #   return Im1
-
-  def __compute_label_info(self, cont_seg, styl_seg):
-    if cont_seg.size == False or styl_seg.size == False:
-      return
-    max_label = np.max(cont_seg)+1
-    self.label_set = np.unique(cont_seg)
-    self.label_indicator = np.zeros(max_label)
-    for l in self.label_set:
-      # if l==0:
-      #   continue
-      o_cont_mask = np.where(cont_seg.reshape(cont_seg.shape[0] * cont_seg.shape[1]) == l)
-      o_styl_mask = np.where(styl_seg.reshape(styl_seg.shape[0] * styl_seg.shape[1]) == l)
-      if o_cont_mask[0].size <= 10 or o_styl_mask[0].size <= 10 or \
-        self.__large_dff(o_cont_mask[0].size, o_styl_mask[0].size):
-        continue
-      self.label_indicator[l] = 1
-
-  def __feature_wct(self, cont_feat, styl_feat, cont_seg, styl_seg):
-    cont_c, cont_h, cont_w = cont_feat.size(0),cont_feat.size(1),cont_feat.size(2)
-    styl_c, styl_h, styl_w = styl_feat.size(0),styl_feat.size(1),styl_feat.size(2)
-    cont_feat_view = cont_feat.view(cont_c, -1).clone()
-    styl_feat_view = styl_feat.view(styl_c, -1).clone()
-    target_feature = cont_feat.view(cont_c, -1).clone()
-
-    if cont_seg.size == False or styl_seg.size == False:
-      tmp_target_feature = self.__wct_core(cont_feat_view, styl_feat_view)
-      target_feature = tmp_target_feature.view_as(cont_feat)
-      ccsF = target_feature.float().unsqueeze(0)
-      return ccsF
-
-    t_cont_seg = np.asarray(Image.fromarray(cont_seg, mode='RGB').resize((cont_w, cont_h), Image.NEAREST))
-    t_styl_seg = np.asarray(Image.fromarray(styl_seg, mode='RGB').resize((styl_w, styl_h), Image.NEAREST))
-
-    for l in self.label_set:
-      if self.label_indicator[l]==0:
-        continue
-      cont_mask = np.where(t_cont_seg.reshape(t_cont_seg.shape[0] * t_cont_seg.shape[1]) == l)
-      styl_mask = np.where(t_styl_seg.reshape(t_styl_seg.shape[0] * t_styl_seg.shape[1]) == l)
-      if cont_mask[0].size <= 0 or styl_mask[0].size <= 0 :
-        continue
-      cont_indi = torch.LongTensor(cont_mask[0]).cuda(0)
-      styl_indi = torch.LongTensor(styl_mask[0]).cuda(0)
-      cFFG = torch.index_select(cont_feat_view, 1, cont_indi)
-      sFFG = torch.index_select(styl_feat_view, 1, styl_indi)
-      tmp_target_feature = self.__wct_core(cFFG, sFFG)
-      target_feature.index_copy_(1, cont_indi, tmp_target_feature)
-
-    target_feature = target_feature.view_as(cont_feat)
-    ccsF = target_feature.float().unsqueeze(0)
-    return ccsF
-
-  def __wct_core(self, cont_feat, styl_feat):
-    cFSize = cont_feat.size()
-    c_mean = torch.mean(cont_feat, 1)  # c x (h x w)
-    c_mean = c_mean.unsqueeze(1).expand_as(cont_feat)
-    cont_feat = cont_feat - c_mean
-
-    iden = torch.eye(cFSize[0]).cuda()#.double()
-    contentConv = torch.mm(cont_feat, cont_feat.t()).div(cFSize[1] - 1) + iden
-    # del iden
-    c_u, c_e, c_v = torch.svd(contentConv, some=False)
-    # c_e2, c_v = torch.eig(contentConv, True)
-    # c_e = c_e2[:,0]
-
-    k_c = cFSize[0]
-    for i in range(cFSize[0]-1,-1,-1):
-      if c_e[i] >= 0.00001:
-        k_c = i+1
-        break
-
-    sFSize = styl_feat.size()
-    s_mean = torch.mean(styl_feat, 1)
-    styl_feat = styl_feat - s_mean.unsqueeze(1).expand_as(styl_feat)
-    styleConv = torch.mm(styl_feat, styl_feat.t()).div(sFSize[1] - 1)
-    s_u, s_e, s_v = torch.svd(styleConv, some=False)
-
-    k_s = sFSize[0]
-    for i in range(sFSize[0]-1,-1,-1):
-      if s_e[i] >= 0.00001:
-        k_s = i+1
-        break
-
-    c_d = (c_e[0:k_c]).pow(-0.5)
-    step1 = torch.mm(c_v[:, 0:k_c], torch.diag(c_d))
-    step2 = torch.mm(step1, (c_v[:, 0:k_c].t()))
-    whiten_cF = torch.mm(step2, cont_feat)
-
-    s_d = (s_e[0:k_s]).pow(0.5)
-    targetFeature = torch.mm(torch.mm(torch.mm(s_v[:, 0:k_s], torch.diag(s_d)), (s_v[:, 0:k_s].t())), whiten_cF)
-    targetFeature = targetFeature + s_mean.unsqueeze(1).expand_as(targetFeature)
-    return targetFeature
-
-  def __large_dff(self, a, b):
-    return a / b >= 100 or b / a >= 100

--- a/process_stylization_examples.py
+++ b/process_stylization_examples.py
@@ -2,23 +2,17 @@
 Copyright (C) 2018 NVIDIA Corporation.  All rights reserved.
 Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 """
-import os
+
 import argparse
+import os
+
+import torch
 
 from photo_wct import PhotoWCT
 import process_stylization
 
 parser = argparse.ArgumentParser(description='Photorealistic Image Stylization')
-parser.add_argument('--vgg1', default='./models/vgg_normalised_conv1_1_mask.t7', help='Path to the VGG conv1_1')
-parser.add_argument('--vgg2', default='./models/vgg_normalised_conv2_1_mask.t7', help='Path to the VGG conv2_1')
-parser.add_argument('--vgg3', default='./models/vgg_normalised_conv3_1_mask.t7', help='Path to the VGG conv3_1')
-parser.add_argument('--vgg4', default='./models/vgg_normalised_conv4_1_mask.t7', help='Path to the VGG conv4_1')
-parser.add_argument('--vgg5', default='./models/vgg_normalised_conv5_1_mask.t7', help='Path to the VGG conv5_1')
-parser.add_argument('--decoder5', default='./models/feature_invertor_conv5_1_mask.t7', help='Path to the decoder5')
-parser.add_argument('--decoder4', default='./models/feature_invertor_conv4_1_mask.t7', help='Path to the decoder4')
-parser.add_argument('--decoder3', default='./models/feature_invertor_conv3_1_mask.t7', help='Path to the decoder3')
-parser.add_argument('--decoder2', default='./models/feature_invertor_conv2_1_mask.t7', help='Path to the decoder2')
-parser.add_argument('--decoder1', default='./models/feature_invertor_conv1_1_mask.t7', help='Path to the decoder1')
+parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth', help='Path to the PhotoWCT model')
 args = parser.parse_args()
 
 folder = 'examples'
@@ -31,7 +25,8 @@ cont_img_list = [f for f in os.listdir(cont_img_folder) if os.path.isfile(os.pat
 cont_img_list.sort()
 
 # Load model
-p_wct = PhotoWCT(args)
+p_wct = PhotoWCT()
+p_wct.load_state_dict(torch.load(args.model))
 p_wct.cuda(0)
 
 for f in cont_img_list:

--- a/process_stylization_examples.py
+++ b/process_stylization_examples.py
@@ -3,6 +3,7 @@ Copyright (C) 2018 NVIDIA Corporation.  All rights reserved.
 Licensed under the CC BY-NC-SA 4.0 license (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 """
 
+from __future__ import print_function
 import argparse
 import os
 
@@ -12,7 +13,8 @@ from photo_wct import PhotoWCT
 import process_stylization
 
 parser = argparse.ArgumentParser(description='Photorealistic Image Stylization')
-parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth', help='Path to the PhotoWCT model')
+parser.add_argument('--model', default='./PhotoWCTModels/photo_wct.pth',
+                    help='Path to the PhotoWCT model. These are provided by the PhotoWCT submodule, please use `git submodule update --init --recursive` to pull.')
 args = parser.parse_args()
 
 folder = 'examples'


### PR DESCRIPTION
This PR:

- Convert torch models to pytorch models (listed in TODOs in the origin code) and `converter.py` shows how it was done. The pytorch model leaves in the submodule `PhotoWCTModels` which makes it easier to download from a server as https://github.com/NVIDIA/FastPhotoStyle/issues/15 suggested.

- The models are refactored into less and clear classes. The layers are named according to the origin paper.

- Fix a bug in `Propagator`. It fails to process images with alpha channels because it does not open them with RGB mode.

- CPU support for PhotoWCT. PhotoWCT can work in CPU mode without using `.cuda()`. This could make it ~10x slower (not too slow yet) but more friendly for those without GPUs or GPUs with less memory as https://github.com/NVIDIA/FastPhotoStyle/issues/17

I'm sorry that some codes in `photo_wct.py` are changed by the (PEP8) code formatter, so not too much of them are actually modified.

Current code are tested. They can work well as before.