### PR TITLE
Removed a literal comparison pitfall from the code

### DIFF
--- a/photo_wct.py
+++ b/photo_wct.py
@@ -54,7 +54,7 @@ class PhotoWCT(nn.Module):
         return Im1
 
     def __compute_label_info(self, cont_seg, styl_seg):
-        if cont_seg.size == False or styl_seg.size == False:
+        if cont_seg.size is False or styl_seg.size is False:
             return
         max_label = np.max(cont_seg) + 1
         self.label_set = np.unique(cont_seg)


### PR DESCRIPTION
**The problem**
The code  was comparing booleans using the operator '==', where in Python the indicated is to use the operator 'is', otherwise we would fall into a literal comparison pitfall. This pitfall was detected using Pylint and generated the following message error code and message:
Pylint code: C0121

Comparison 'styl_seg.size == False' should be 'styl_seg.size is False' if checking for the singleton value False, or 'not styl_seg.size' if testing for falsiness



**Solution**
Removed the '==' operator and changed it to 'is'
